### PR TITLE
Auth, groups, and some ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,43 @@
-### Setup
+## Features
+- Group autoassignment from corp titles
+- Multi-corp support (alliance support soon)
+- Title disallow list
 
+## Setup
+
+### ESI application
+1. Sign in to the [EVE developer portal](https://developers.eveonline.com/)
+2. Select `Manage Applications` -> `Create New Application`
+
+3. Under Connection Type, select "authentication and API access"
+
+4. Choose the following scopes from the list:
+ * `esi-characters.read_titles.v1`
+ * `publicData`
+
+5. For now, put `http://localhost` in the callback.  We will come back and change this.
+
+### wiki.js configuration
+1. clone this project into `server/modules/authentication` under the root of your wiki.js installation.
+2. restart wiki.js
+3. Sign in as an administrator and select `Authentication` from the left nav bar
+4. Select `ADD STRATEGY` and choose Eve Online ESI from the list
+5. Populate the `Client ID` and `Client Secret` with the values provided by the EVE Developer Portal.
+6. Fill in the allowed Corporation names, new line delimited, in `Allowed Corporations`
+7. Fill in any disallowed titles, new line delimited, in `Disallowed Titles`
+8. Toggle `Map Titles to Groups` to true if you would like users to by assigned to groups that match the names of their titles.
+9. Enable `Allow self-registration` and set the email domain to evesso.local.  Leave Assign to group blank.
+
+10. At the bottom of this window copy the `Callback URL / Redirect URI` value (under Configuration Reference)
+11. Click `Apply` at the top right of the window
+
+12. Back in the EVE developer portal, go to applications and select `view application` for your wiki backend
+choose the `Update Details` tab, scroll down to the bottom, and replace the `Callback URL` with the value you copied in step 10.
+`Click Confirm Changes and Update App`
+
+
+
+### local dev setup
 clone this project into `server/modules/authentication` under the root of the
 wiki.js project.
 

--- a/authentication.js
+++ b/authentication.js
@@ -76,6 +76,19 @@ module.exports = {
           }
         }
 
+        // Check for CEO
+        var res = await fetch(`https://esi.evetech.net/latest/corporations/${corpMembership}/?datasource=tranquility&language=en`, {
+          method: 'GET',
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+            'Accept': 'application/json',
+            'User-Agent': 'wiki-js-eve-sso',
+            'Cache-Control': 'no-cache'
+          }
+        })
+        const corpInfo = await res.json()
+        if (corpInfo.ceo_id == profile.CharacterID) { titles.push("CEO") }
+
         // create initial user object
         const user = await WIKI.models.users.processProfile({
           providerKey: req.params.strategy,

--- a/authentication.js
+++ b/authentication.js
@@ -9,19 +9,33 @@ const EveOnlineSsoStrategy = require('passport-eveonline-sso').Strategy;
 module.exports = {
   init(passport, conf) {
     console.log(conf)
-    passport.use(conf.key,
-      new EveOnlineSsoStrategy({
-        clientID: conf.clientID,
-        clientSecret: conf.clientSecret,
-        callbackURL: conf.callbackURL,
-      }, function(accessToken, refreshToken, profile, cb) {
-        console.log(profile)
-        WIKI.models.users.processProfile(profile).then((user) => {
-          return cb(null, user) || true
-        }).catch((err) => {
-          return cb(err, null) || true
+    var client = new EveOnlineSsoStrategy({
+      clientID: conf.clientID,
+      clientSecret: conf.clientSecret,
+      callbackURL: conf.callbackURL,
+      passReqToCallback: true,
+    }, async (req, accessToken, refreshToken, profile, cb) => {
+      try {
+        //console.log(profile) //[DEBUG]
+        const user = await WIKI.models.users.processProfile({
+          providerKey: req.params.strategy,
+          profile: {
+            ...profile,
+            id: profile.CharacterID,
+            displayName: profile.CharacterName,
+            email: `${profile.CharacterID}@evesso.local`,
+            picture: `https://images.evetech.net/characters/${profile.CharacterID}/portrait?tenant=tranquility&size=128`
+          }
         })
+        console.log("record created: %s", user)
+        cb(null, user)
+
+      } catch (err) {
+        console.log("failed: %s", err)
+        //console.log("user: %s", user)
+        cb(err, null)
       }
-      ))
+    })
+    passport.use(conf.key, client)
   }
 }

--- a/authentication.js
+++ b/authentication.js
@@ -3,6 +3,7 @@
 // ------------------------------------
 // Eve Online ESI
 // ------------------------------------
+const _ = require('lodash')
 
 const EveOnlineSsoStrategy = require('passport-eveonline-sso').Strategy;
 
@@ -14,7 +15,7 @@ module.exports = {
       callbackURL: conf.callbackURL,
       passReqToCallback: true,
       scope: "publicData esi-characters.read_titles.v1",
-    }, async (req, accessToken, profile, cb) => {
+    }, async (req, accessToken, refreshToken, profile, cb) => {
       try {
 
         const failTitles = conf.disallowedTitles.split("\n")

--- a/authentication.js
+++ b/authentication.js
@@ -8,15 +8,74 @@ const EveOnlineSsoStrategy = require('passport-eveonline-sso').Strategy;
 
 module.exports = {
   init(passport, conf) {
-    console.log(conf)
     var client = new EveOnlineSsoStrategy({
       clientID: conf.clientID,
       clientSecret: conf.clientSecret,
       callbackURL: conf.callbackURL,
       passReqToCallback: true,
-    }, async (req, accessToken, refreshToken, profile, cb) => {
+      scope: "publicData esi-characters.read_titles.v1",
+    }, async (req, accessToken, profile, cb) => {
       try {
-        //console.log(profile) //[DEBUG]
+
+        const failTitles = conf.disallowedTitles.split("\n")
+        const allowedCorps = conf.allowedCorps.split("\n")
+        // get allowed corp IDs
+        var res = await fetch('https://esi.evetech.net/latest/universe/ids/?datasource=tranquility&language=en', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'User-Agent': 'wiki-js-eve-sso',
+            'Cache-Control': 'no-cache'
+          },
+          body: JSON.stringify(allowedCorps),
+        })
+        const corps = await res.json()
+
+        // fetch corp
+        var res = await fetch(`https://esi.evetech.net/latest/characters/${profile.CharacterID}/?datasource=tranquility`, {
+          method: 'GET',
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+            'Accept': 'application/json',
+            'User-Agent': 'wiki-js-eve-sso',
+            'Cache-Control': 'no-cache'
+          }
+        })
+        var jsonRes = await res.json()
+        const corpMembership = JSON.stringify(jsonRes.corporation_id)
+
+        // verify user corp membership
+        var match = false
+        for (const corp of corps.corporations) {
+          if (corp.id == corpMembership) { match = true }
+        }
+        if (!match) {
+          throw new Error('Character is not a member of an authorized corporation.')
+        }
+
+        // fetch titles
+        var res = await fetch(`https://esi.evetech.net/latest/characters/${profile.CharacterID}/titles/?datasource=tranquility`, {
+          method: 'GET',
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+            'Accept': 'application/json',
+            'User-Agent': 'wiki-js-eve-sso',
+            'Cache-Control': 'no-cache'
+          }
+        })
+        var titles = await res.json()
+        titles = titles.map(t => t.name.replace(/(<([^>]+)>)/gi, ""))
+
+        // handle disallowed titles
+        for (const title of titles) {
+          if (failTitles.includes(title)) {
+            throw new Error(`Character with title ${title} is disallowed.`)
+          }
+        }
+
+        // create initial user object
         const user = await WIKI.models.users.processProfile({
           providerKey: req.params.strategy,
           profile: {
@@ -27,12 +86,25 @@ module.exports = {
             picture: `https://images.evetech.net/characters/${profile.CharacterID}/portrait?tenant=tranquility&size=128`
           }
         })
-        console.log("record created: %s", user)
+
+        // assign groups from titles
+        if (conf.mapGroups) {
+          const groups = titles
+          if (groups && _.isArray(groups)) {
+            const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).map(g => g.id)
+            const expectedGroups = Object.values(WIKI.auth.groups).filter(g => groups.includes(g.name)).map(g => g.id)
+            for (const groupId of _.difference(expectedGroups, currentGroups)) {
+              await user.$relatedQuery('groups').relate(groupId)
+            }
+            for (const groupId of _.difference(currentGroups, expectedGroups)) {
+              await user.$relatedQuery('groups').unrelate().where('groupId', groupId)
+            }
+          }
+        }
         cb(null, user)
 
       } catch (err) {
-        console.log("failed: %s", err)
-        //console.log("user: %s", user)
+        console.log("eve esi sso failed: %s", err)
         cb(err, null)
       }
     })

--- a/definition.yml
+++ b/definition.yml
@@ -14,3 +14,21 @@ props:
     title: 'Client Secret'
     hint: 'Application Client Secret'
     order: 2
+  allowedCorps:
+    type: String
+    multiline: true
+    title: 'Allowed Corporations'
+    hint: 'A list of corporation names which are allowed to join the wiki. [new line delimited]'
+    order: 3
+  disallowedTitles:
+    type: String
+    multiline: true
+    title: 'Disallowed Titles'
+    hint: 'A list of titles that are forbidden from joining the wiki.  [new line delimited]'
+    order: 4
+  mapGroups:
+    type: Boolean
+    default: false
+    title: 'Map Titles to Groups'
+    hint: 'If true, all members will be placed in the groups matching their titles.'
+    order: 5


### PR DESCRIPTION
This release supports

1. Auth via esi
2. Allow list of corp names
3. block list for corp titles
4. auto-assignment of groups matching corp titles on character sign in

